### PR TITLE
fix: converge AccessDenied when fetching object to 404 NoSuchKey

### DIFF
--- a/src/read/_pretty.js
+++ b/src/read/_pretty.js
@@ -50,7 +50,12 @@ module.exports = async function pretty (params) {
       return await getter(file)
     }
     catch (err) {
-      if (err.name === 'NoSuchKey') {
+      /**
+       * If you have the s3:ListBucket permission on the bucket, Amazon S3 will return an HTTP status code 404 ("no such key") error.
+       * If you don’t have the s3:ListBucket permission, Amazon S3 will return an HTTP status code 403 ("access denied") error.
+       */
+      if ([ 'NoSuchKey', 'AccessDenied' ].includes(err.name)) {
+        err.name = 'NoSuchKey' // converge to NoSuchKey 404
         err.statusCode = 404
         return err
       }

--- a/src/read/_s3.js
+++ b/src/read/_s3.js
@@ -126,7 +126,11 @@ module.exports = async function readS3 (params) {
     return response
   }
   catch (err) {
-    let notFound = err.name === 'NoSuchKey'
+    /**
+     * If you have the s3:ListBucket permission on the bucket, Amazon S3 will return an HTTP status code 404 ("no such key") error.
+     * If you don’t have the s3:ListBucket permission, Amazon S3 will return an HTTP status code 403 ("access denied") error.
+     */
+    let notFound = [ 'NoSuchKey', 'AccessDenied' ].includes(err.name)
     if (notFound) {
       if (config.passthru) return null
       return pretty({ Bucket, Key, assets, headers, isFolder, prefix })

--- a/test/unit/src/read/_pretty-test.js
+++ b/test/unit/src/read/_pretty-test.js
@@ -141,6 +141,37 @@ test('Peek and do not find nested index.html', async t => {
   reset()
 })
 
+
+test('Peek and do not find nested index.html - 403', async t => {
+  t.plan(4)
+  // AWS
+  process.env.ARC_ENV = 'staging'
+  Key = 'notOk',
+  isFolder = true
+  errorState = 'AccessDenied'
+  let result = await pretty({
+    Bucket,
+    Key,
+    headers,
+    isFolder
+  })
+  t.equal(result.statusCode, 404, 'Returns statusCode of 404 if S3 file is not found')
+  t.match(result.body, /NoSuchKey/, 'Error message included in response from S3')
+
+  // Local
+  process.env.ARC_ENV = 'testing'
+  result = await pretty({
+    Bucket,
+    Key,
+    headers,
+    isFolder,
+    sandboxPath,
+  })
+  t.equal(result.statusCode, 404, 'Returns statusCode of 404 if local file is not found')
+  t.match(result.body, /NoSuchKey/, 'Error message included in response from local')
+  reset()
+})
+
 test('Return a custom 404', async t => {
   t.plan(8)
   // AWS

--- a/test/unit/src/read/_s3-test.js
+++ b/test/unit/src/read/_s3-test.js
@@ -282,11 +282,29 @@ test('S3 proxy reader hands off to pretty URLifier on 404', async t => {
   errorState = false
 })
 
+test('S3 proxy reader hands off to pretty URLifier on 403', async t => {
+  setup()
+  t.plan(1)
+  errorState = 'AccessDenied'
+  let result = await readS3(read())
+  t.equal(result, 'pretty', 'File not found returns response from pretty')
+  errorState = false
+})
 
-test('S3 proxy reader responds with null in passthru mode', async t => {
+
+test('S3 proxy reader responds with null in passthru mode on 404', async t => {
   setup()
   t.plan(1)
   errorState = 'NoSuchKey'
+  let result = await readS3(read({ config: { passthru: true } }))
+  t.equal(result, null, 'File not found returns null in passthru mode')
+  errorState = false
+})
+
+test('S3 proxy reader responds with null in passthru mode on 403', async t => {
+  setup()
+  t.plan(1)
+  errorState = 'AccessDenied'
   let result = await readS3(read({ config: { passthru: true } }))
   t.equal(result, null, 'File not found returns null in passthru mode')
   errorState = false


### PR DESCRIPTION
The StaticBucketPolicy added to the s3 bucket, as part of Arc 10,
in lieu of ACLs, made it such that a 403 could be received from
the s3.getObject action:

> If you have the s3:ListBucket permission on the bucket, Amazon S3
will return an HTTP status code 404 ("no such key") error.
If you don’t have the s3:ListBucket permission,
Amazon S3 will return an HTTP status code 403 ("access denied") error.

So asap converges the 403 case, when fetching objects, to the 404 case

## Thank you for helping out! ✨

### We really appreciate your commitment to improving Architect

To maintain a high standard of quality in our releases, before merging every pull request we ask that you've completed the following:

- [ ] Forked the repo and created your branch from `master`
- [ ] Made sure tests pass (run `npm it` from the repo root)
- [ ] Expanded test coverage related to your changes:
  - [ ] Added and/or updated unit tests (if appropriate)
  - [ ] Added and/or updated integration tests (if appropriate)
- [ ] Updated relevant documentation:
  - [ ] Internal to this repo (e.g. `readme.md`, help docs, inline docs & comments, etc.)
  - [ ] [Architect docs (arc.codes)](https://github.com/architect/arc.codes)
- [ ] Summarized your changes in `changelog.md`
- [ ] Linked to any related issues, PRs, etc. below that may relate to, consume, or necessitate these changes

Please also be sure to completed the CLA (if you haven't already).

Learn more about [contributing to Architect here](https://arc.codes/intro/community).

Thanks again!
