### PR TITLE
Alter order of preference for bucket name resolution so passed params can override env var

### DIFF
--- a/src/asap.js
+++ b/src/asap.js
@@ -39,7 +39,7 @@ function asap (config = {}) {
       : configBucket?.['staging']
     // Ok, all that out of the way, let's set the actual bucket, eh?
     let needBucket = config.env !== 'testing'
-    let Bucket = ARC_STATIC_BUCKET || bucketSetting
+    let Bucket = bucketSetting || ARC_STATIC_BUCKET
     if (!Bucket && needBucket) {
       return errors.proxyConfig
     }


### PR DESCRIPTION
Currently, if you use @asap in an Architect deployed function, where ARC_STATIC_BUCKET is populated by default, you cannot declare an alternative bucket to the asap function, to attempt to load assets from another bucket.

The documentation doesn't make it clear that this shouldn't work, so I assumed it's just a bug in the order things are considered in the function, so I've reversed them to that a passed bucket name will always override the env var and it will only be used as a default when no value is passed to the function.